### PR TITLE
Ajout sauvegarde USB et gestionnaire

### DIFF
--- a/README_USB.md
+++ b/README_USB.md
@@ -1,0 +1,18 @@
+# Sauvegarde USB & Gestionnaire
+
+## Détection USB
+- **Linux / Raspberry Pi** : inspection des points de montage dans `/media/*/*` et `/run/media/*/*` en privilégiant le premier volume amovible disponible et en évitant les montages système (`boot`, `system`, `efi`, etc.).
+- **Windows** : interrogation de l'API système (`GetLogicalDrives` / `GetDriveTypeW`) pour lister les lecteurs amovibles (ex. `E:\`, `F:\`). Un repli scanne les lettres `D:` à `Z:` si l'API n'est pas accessible.
+- **macOS** : parcours des volumes présents dans `/Volumes/`.
+
+La fonction utilitaire `get_usb_mount_point()` retourne le premier point de montage détecté ou `None` si aucune clé n'est disponible.
+
+## Nouveautés UI
+- Bouton **« Sauvegarder »** sur l'écran de révision : copie immédiatement la photo en cours dans `SimpleBooth/` à la racine de la clé USB avec un nom horodaté (`YYYYMMDD_HHMMSS.ext`). Un toast confirme la réussite ou signale l'erreur.
+- Bouton **« Gérer USB »** sur l'écran principal : ouvre un gestionnaire listant les photos stockées sur la clé (aperçus, nom, taille, date). On peut rafraîchir la liste, pré-visualiser une photo, la supprimer (confirmation « Êtes-vous sûr ? ») ou fermer le panneau.
+- Les notifications (« Photo sauvegardée… », « Aucune clé USB détectée… ») sont affichées en français via des toasts visuels.
+
+## Limitations connues
+- La création de miniatures exploite directement les fichiers originaux : de nombreuses images lourdes peuvent ralentir le chargement initial.
+- Les suppressions utilisent une confirmation navigateur standard.
+- Si aucune clé USB n'est branchée ou si les permissions manquent, l'interface affiche un message dédié et aucune action destructive n'est réalisée.

--- a/storage_usb.py
+++ b/storage_usb.py
@@ -1,0 +1,236 @@
+"""Utilitaires pour la gestion de la sauvegarde USB."""
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+logger = logging.getLogger(__name__)
+
+USB_DEFAULT_SUBFOLDER = "SimpleBooth"
+
+
+@dataclass
+class PhotoMeta:
+    """Métadonnées minimalistes pour une photo stockée sur USB."""
+
+    name: str
+    path: str
+    size: int
+    mtime: float
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "path": self.path,
+            "size": self.size,
+            "mtime": self.mtime,
+        }
+
+
+def _iter_linux_mount_candidates() -> Iterable[Path]:
+    bases = [Path("/media"), Path("/run/media")]
+    for base in bases:
+        if not base.exists():
+            continue
+        for first_level in base.iterdir():
+            if not first_level.is_dir():
+                continue
+            # Certains systèmes montent directement à /media/USB
+            if _is_valid_mount(first_level):
+                yield first_level
+            for second_level in first_level.iterdir():
+                if second_level.is_dir():
+                    yield second_level
+
+
+def _iter_macos_mount_candidates() -> Iterable[Path]:
+    base = Path("/Volumes")
+    if base.exists():
+        for child in base.iterdir():
+            if child.is_dir():
+                yield child
+
+
+def _iter_windows_mount_candidates() -> Iterable[Path]:
+    try:
+        import ctypes
+
+        drive_bits = ctypes.windll.kernel32.GetLogicalDrives()
+        for letter in (f"{chr(65 + i)}:" for i in range(26)):
+            mask = 1 << (ord(letter[0]) - 65)
+            if not drive_bits & mask:
+                continue
+            drive_type = ctypes.windll.kernel32.GetDriveTypeW(f"{letter}\\")
+            # 2 = DRIVE_REMOVABLE
+            if drive_type == 2:
+                yield Path(f"{letter}\\")
+    except Exception as exc:  # pragma: no cover - dépend du système
+        logger.debug("[USB] Échec de détection Windows via ctypes: %s", exc)
+        # Fallback simple: lettres E à Z
+        for letter in "DEFGHIJKLMNOPQRSTUVWXYZ":
+            path = Path(f"{letter}:/")
+            if path.exists():
+                yield path
+
+
+def _is_valid_mount(path: Path) -> bool:
+    try:
+        if not path.exists() or not path.is_dir():
+            return False
+        # Éviter les montages système évidents
+        lower = path.name.lower()
+        if any(keyword in lower for keyword in ("system", "boot", "root", "efi")):
+            return False
+        # Vérifie que le chemin correspond à un point de montage réel quand possible
+        if hasattr(os.path, "ismount") and os.path.ismount(path):
+            return True
+        # Sur Windows certains lecteurs ne sont pas considérés comme montés
+        return True
+    except Exception as exc:
+        logger.debug("[USB] Chemin %s ignoré: %s", path, exc)
+        return False
+
+
+def get_usb_mount_point() -> Optional[Path]:
+    """Retourne le point de montage de la première clé USB détectée."""
+
+    logger.debug("[USB] Détection du point de montage USB...")
+    candidates: Iterable[Path]
+
+    if sys.platform.startswith("linux"):
+        candidates = _iter_linux_mount_candidates()
+    elif sys.platform.startswith("win"):
+        candidates = _iter_windows_mount_candidates()
+    elif sys.platform.startswith("darwin"):
+        candidates = _iter_macos_mount_candidates()
+    else:
+        candidates = []
+
+    for candidate in candidates:
+        if _is_valid_mount(candidate):
+            logger.info("[USB] Point de montage détecté: %s", candidate)
+            return candidate
+
+    logger.info("[USB] Aucune clé USB détectée")
+    return None
+
+
+def ensure_usb_folder_exists(subfolder: str = USB_DEFAULT_SUBFOLDER) -> Path:
+    """S'assure que le dossier de sauvegarde existe sur la clé USB."""
+
+    mount_point = get_usb_mount_point()
+    if not mount_point:
+        raise FileNotFoundError("Aucune clé USB détectée")
+
+    destination = mount_point / subfolder
+    try:
+        destination.mkdir(parents=True, exist_ok=True)
+    except PermissionError as exc:
+        logger.error("[USB] Permission refusée pour créer %s: %s", destination, exc)
+        raise
+    except OSError as exc:
+        logger.error("[USB] Impossible de créer %s: %s", destination, exc)
+        raise
+
+    return destination
+
+
+def _generate_timestamp_name(original: Path, dest_name_timestamped: bool) -> str:
+    if not dest_name_timestamped:
+        return original.name
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    suffix = original.suffix or ".jpg"
+    return f"{timestamp}{suffix}".replace(" ", "_")
+
+
+def _check_free_space(destination: Path, file_size: int) -> None:
+    usage = shutil.disk_usage(destination)
+    if usage.free < file_size:
+        logger.error("[USB] Espace disque insuffisant: %s restant", usage.free)
+        raise OSError("Espace disque insuffisant sur la clé USB")
+
+
+def _build_unique_path(destination_folder: Path, filename: str) -> Path:
+    base_path = destination_folder / filename
+    candidate = base_path
+    counter = 1
+    while candidate.exists():
+        candidate = destination_folder / f"{base_path.stem}_{counter}{base_path.suffix}"
+        counter += 1
+    return candidate
+
+
+def save_photo_to_usb(image_source, dest_name_timestamped: bool = True, subfolder: str = USB_DEFAULT_SUBFOLDER) -> Path:
+    """Sauvegarde une photo (chemin ou bytes) sur la clé USB et retourne le chemin créé."""
+
+    destination_folder = ensure_usb_folder_exists(subfolder=subfolder)
+
+    if isinstance(image_source, (str, Path)):
+        source_path = Path(image_source)
+        if not source_path.exists():
+            raise FileNotFoundError(f"Fichier introuvable: {source_path}")
+        file_size = source_path.stat().st_size
+        _check_free_space(destination_folder, file_size)
+        dest_name = _generate_timestamp_name(source_path, dest_name_timestamped)
+        dest_path = _build_unique_path(destination_folder, dest_name)
+        shutil.copy2(source_path, dest_path)
+        logger.info("[USB] Photo copiée sur USB: %s", dest_path)
+        return dest_path
+
+    if isinstance(image_source, (bytes, bytearray)):
+        data = bytes(image_source)
+        file_size = len(data)
+        _check_free_space(destination_folder, file_size)
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        dest_path = _build_unique_path(destination_folder, f"{timestamp}.jpg")
+        with open(dest_path, "wb") as output:
+            output.write(data)
+        logger.info("[USB] Photo sauvegardée depuis bytes: %s", dest_path)
+        return dest_path
+
+    raise TypeError("image_source doit être un chemin ou des octets")
+
+
+def list_usb_photos(subfolder: str = USB_DEFAULT_SUBFOLDER) -> List[dict]:
+    """Liste les photos présentes sur la clé USB."""
+
+    folder = ensure_usb_folder_exists(subfolder=subfolder)
+    photos: List[PhotoMeta] = []
+    for file in sorted(folder.glob("*"), key=lambda p: p.stat().st_mtime, reverse=True):
+        if not file.is_file():
+            continue
+        stats = file.stat()
+        photos.append(PhotoMeta(
+            name=file.name,
+            path=str(file),
+            size=stats.st_size,
+            mtime=stats.st_mtime,
+        ))
+    logger.info("[USB] %d photos détectées sur la clé", len(photos))
+    return [photo.to_dict() for photo in photos]
+
+
+def delete_usb_photo(path: str, subfolder: str = USB_DEFAULT_SUBFOLDER) -> bool:
+    """Supprime une photo du dossier USB."""
+
+    folder = ensure_usb_folder_exists(subfolder=subfolder)
+    target = folder / Path(path).name
+    if not target.exists():
+        logger.warning("[USB] Photo introuvable pour suppression: %s", target)
+        return False
+    try:
+        target.unlink()
+        logger.info("[USB] Photo supprimée: %s", target)
+        return True
+    except PermissionError as exc:
+        logger.error("[USB] Permission refusée pour supprimer %s: %s", target, exc)
+        raise
+    except OSError as exc:
+        logger.error("[USB] Erreur lors de la suppression de %s: %s", target, exc)
+        raise

--- a/templates/base.html
+++ b/templates/base.html
@@ -73,6 +73,24 @@
             font-weight: bold;
             min-height: 60px;
         }
+
+        .btn-usb {
+            background: linear-gradient(45deg, #1e88e5, #1565c0);
+            border: none;
+            border-radius: 15px;
+            padding: 15px 30px;
+            font-size: 1.2em;
+            font-weight: bold;
+            color: #fff;
+            min-height: 60px;
+            transition: all 0.3s ease;
+        }
+
+        .btn-usb:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 5px 15px rgba(30, 136, 229, 0.4);
+            color: #fff;
+        }
         
         .video-container {
             position: relative;
@@ -240,13 +258,47 @@
                 autohide: true,
                 delay: 5000
             });
-            
-            // Ajouter une animation de sortie
+
             toastElement.addEventListener('hide.bs.toast', function() {
                 toastElement.style.animation = 'slideOutDown 0.5s ease-in';
             });
         });
     });
+
+    function showToast(message, type = 'success') {
+        const container = document.querySelector('.toast-container');
+        if (!container) {
+            alert(message);
+            return;
+        }
+
+        const toastElement = document.createElement('div');
+        toastElement.className = 'toast show custom-toast';
+        toastElement.setAttribute('role', 'alert');
+        toastElement.dataset.bsAutohide = 'true';
+        toastElement.dataset.bsDelay = '5000';
+
+        const iconClass = type === 'error' ? 'exclamation-triangle text-danger' : 'check-circle text-success';
+        const title = type === 'error' ? 'Erreur' : 'Succès';
+        const safeMessage = document.createElement('div');
+        safeMessage.textContent = message;
+
+        toastElement.innerHTML = `
+            <div class="toast-body text-center p-4">
+                <div class="mb-2">
+                    <i class="fas fa-${iconClass}" style="font-size: 2rem;"></i>
+                </div>
+                <div class="fw-bold mb-2" style="font-size: 1.1rem;">${title}</div>
+                <div>${safeMessage.innerHTML}</div>
+                <button type="button" class="btn-close position-absolute top-0 end-0 m-2" data-bs-dismiss="toast" style="font-size: 0.8rem;"></button>
+            </div>
+        `;
+
+        container.appendChild(toastElement);
+        const toast = new bootstrap.Toast(toastElement);
+        toast.show();
+        toastElement.addEventListener('hidden.bs.toast', () => toastElement.remove());
+    }
     </script>
     
     <style>

--- a/templates/index.html
+++ b/templates/index.html
@@ -22,6 +22,29 @@
             padding: 8px 16px;
         }
     }
+
+    .usb-photo-item {
+        border-radius: 15px;
+        overflow: hidden;
+        cursor: pointer;
+        transition: transform 0.2s ease, box-shadow 0.2s ease, border 0.2s ease;
+    }
+
+    .usb-photo-item:hover {
+        transform: translateY(-4px);
+        box-shadow: 0 8px 20px rgba(0, 0, 0, 0.25);
+    }
+
+    .usb-photo-item.active {
+        border: 3px solid #1e88e5;
+        box-shadow: 0 8px 20px rgba(30, 136, 229, 0.35);
+    }
+
+    .usb-photo-item img {
+        object-fit: cover;
+        width: 100%;
+        height: 100%;
+    }
     </style>
     <!-- Conteneur vidéo avec marges élégantes -->
     <div class="video-container position-relative d-flex align-items-center justify-content-center" id="videoContainer" style="height: calc(100vh - 2rem); width: calc(100vw - 2rem);">
@@ -41,10 +64,17 @@
         
         <!-- Bouton capture en overlay -->
         <div class="position-absolute bottom-0 start-50 translate-middle-x mb-4" style="z-index: 5;">
-            <button id="captureBtn" class="btn btn-danger btn-lg px-5 py-3" onclick="capturePhoto()" 
-                    style="font-size: 1.5rem; border-radius: 50px; box-shadow: 0 4px 15px rgba(0,0,0,0.3);">
-                <i class="fas fa-camera fa-2x"></i>
-            </button>
+            <div class="d-flex flex-column flex-md-row align-items-center gap-3">
+                <button id="captureBtn" class="btn btn-danger btn-lg px-5 py-3" onclick="capturePhoto()"
+                        style="font-size: 1.5rem; border-radius: 50px; box-shadow: 0 4px 15px rgba(0,0,0,0.3);">
+                    <i class="fas fa-camera fa-2x"></i>
+                </button>
+                <button id="usbManagerBtn" class="btn btn-usb btn-lg px-4 py-3" onclick="openUsbManager()"
+                        style="font-size: 1.1rem; border-radius: 20px; box-shadow: 0 4px 15px rgba(0,0,0,0.3);">
+                    <i class="fas fa-usb me-2"></i>
+                    Gérer USB
+                </button>
+            </div>
         </div>
     </div>
     
@@ -55,6 +85,55 @@
             <div>
                 <strong>Attention !</strong><br>
                 <small>Vérifiez le papier de l'imprimante avant de prendre une photo</small>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Modale de gestion USB -->
+<div class="modal fade" id="usbManagerModal" tabindex="-1" aria-labelledby="usbManagerModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-xl modal-dialog-centered modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header" style="background: linear-gradient(45deg, #1e88e5, #1565c0); color: #fff;">
+                <h5 class="modal-title" id="usbManagerModalLabel">
+                    <i class="fas fa-usb me-2"></i>
+                    Gestion des photos USB
+                </h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Fermer"></button>
+            </div>
+            <div class="modal-body">
+                <div id="usbManagerAlert" class="alert alert-warning d-none" role="alert">
+                    Aucune clé USB détectée. Branchez une clé et cliquez sur Rafraîchir.
+                </div>
+                <div id="usbManagerContent">
+                    <div class="row g-4">
+                        <div class="col-lg-7">
+                            <div id="usbPhotosContainer" class="row g-3"></div>
+                        </div>
+                        <div class="col-lg-5">
+                            <div class="card bg-dark text-white h-100 shadow-sm">
+                                <div class="card-body d-flex flex-column justify-content-center" id="usbPhotoPreview">
+                                    <p class="text-muted text-center mb-0">Sélectionnez une photo pour l'aperçu.</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer d-flex justify-content-between">
+                <div>
+                    <small class="text-muted" id="usbMountInfo"></small>
+                </div>
+                <div class="d-flex gap-2">
+                    <button type="button" class="btn btn-usb" id="usbRefreshBtn">
+                        <i class="fas fa-sync-alt me-2"></i>
+                        Rafraîchir
+                    </button>
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
+                        <i class="fas fa-times me-2"></i>
+                        Fermer
+                    </button>
+                </div>
             </div>
         </div>
     </div>
@@ -87,10 +166,25 @@
 {% block scripts %}
 <script>
 let isCapturing = false;
+let usbManagerModal = null;
+let usbPhotos = [];
+let selectedUsbPhotoName = null;
 
 // Initialiser la caméra au chargement de la page
 document.addEventListener('DOMContentLoaded', function() {
     initCamera();
+    const refreshBtn = document.getElementById('usbRefreshBtn');
+    if (refreshBtn) {
+        refreshBtn.addEventListener('click', () => refreshUsbPhotos());
+    }
+    const modalEl = document.getElementById('usbManagerModal');
+    if (modalEl) {
+        modalEl.addEventListener('hidden.bs.modal', () => {
+            selectedUsbPhotoName = null;
+            updateUsbPreview(null);
+            highlightSelectedUsb(null);
+        });
+    }
 });
 
 function initCamera() {
@@ -196,6 +290,228 @@ async function takePicture() {
         alert('Erreur lors de la prise de photo: ' + error.message);
         
         resetCaptureButton();
+    }
+}
+
+function openUsbManager() {
+    if (!usbManagerModal) {
+        const modalElement = document.getElementById('usbManagerModal');
+        usbManagerModal = new bootstrap.Modal(modalElement);
+    }
+    refreshUsbPhotos();
+    usbManagerModal.show();
+}
+
+async function refreshUsbPhotos(showToastOnError = false) {
+    const container = document.getElementById('usbPhotosContainer');
+    const alertBox = document.getElementById('usbManagerAlert');
+    const mountInfo = document.getElementById('usbMountInfo');
+
+    if (container) {
+        container.innerHTML = `
+            <div class="col-12 text-center text-muted py-5">
+                <i class="fas fa-spinner fa-spin fa-2x mb-3"></i>
+                <div>Chargement des photos...</div>
+            </div>
+        `;
+    }
+    if (alertBox) {
+        alertBox.classList.add('d-none');
+    }
+    if (mountInfo) {
+        mountInfo.textContent = '';
+    }
+
+    try {
+        const response = await fetch('/usb/photos');
+        const result = await response.json();
+        if (!response.ok || !result.success) {
+            throw new Error(result.error || 'Erreur lors du chargement de la clé USB');
+        }
+
+        usbPhotos = result.photos || [];
+        if (mountInfo && result.mount_point) {
+            mountInfo.textContent = `Montage : ${result.mount_point}`;
+        }
+
+        renderUsbPhotos();
+        if (!usbPhotos.length && container) {
+            container.innerHTML = `
+                <div class="col-12 text-center text-muted py-5">
+                    Aucune photo dans le dossier SimpleBooth.
+                </div>
+            `;
+            updateUsbPreview(null);
+        }
+    } catch (error) {
+        console.error('Erreur lors du chargement USB:', error);
+        if (alertBox) {
+            const message = error.message && !error.message.includes('Aucune clé USB détectée')
+                ? error.message
+                : 'Aucune clé USB détectée. Branchez une clé et cliquez sur Rafraîchir.';
+            alertBox.textContent = message;
+            alertBox.classList.remove('d-none');
+            if (showToastOnError) {
+                showToast(message, 'error');
+            }
+        }
+        if (container) {
+            container.innerHTML = '';
+        }
+        if (mountInfo) {
+            mountInfo.textContent = '';
+        }
+        usbPhotos = [];
+        selectedUsbPhotoName = null;
+        updateUsbPreview(null);
+        highlightSelectedUsb(null);
+    }
+}
+
+function renderUsbPhotos() {
+    const container = document.getElementById('usbPhotosContainer');
+    if (!container) return;
+
+    container.innerHTML = '';
+    usbPhotos.forEach(photo => {
+        const col = document.createElement('div');
+        col.className = 'col-6 col-md-4 col-xl-3';
+
+        const card = document.createElement('div');
+        card.className = 'usb-photo-item card h-100 border-0 shadow-sm';
+        card.dataset.name = photo.name;
+
+        card.innerHTML = `
+            <div class="ratio ratio-4x3">
+                <img src="${photo.url}" alt="${photo.name}" class="w-100 h-100">
+            </div>
+            <div class="card-body p-3">
+                <div class="fw-bold text-truncate" title="${photo.name}">${photo.name}</div>
+                <div class="small text-muted">${formatBytes(photo.size)}</div>
+                <div class="small text-muted">${formatDate(photo.mtime)}</div>
+            </div>
+        `;
+
+        card.addEventListener('click', () => {
+            selectedUsbPhotoName = photo.name;
+            highlightSelectedUsb(photo.name);
+            updateUsbPreview(photo);
+        });
+
+        if (photo.name === selectedUsbPhotoName) {
+            card.classList.add('active');
+        }
+
+        col.appendChild(card);
+        container.appendChild(col);
+    });
+
+    if (selectedUsbPhotoName) {
+        const selectedPhoto = usbPhotos.find(photo => photo.name === selectedUsbPhotoName);
+        if (selectedPhoto) {
+            updateUsbPreview(selectedPhoto);
+            highlightSelectedUsb(selectedUsbPhotoName);
+            return;
+        }
+    }
+
+    updateUsbPreview(null);
+}
+
+function updateUsbPreview(photo) {
+    const preview = document.getElementById('usbPhotoPreview');
+    if (!preview) return;
+
+    if (!photo) {
+        preview.innerHTML = '<p class="text-muted text-center mb-0">Sélectionnez une photo pour l\'aperçu.</p>';
+        return;
+    }
+
+    preview.innerHTML = `
+        <div class="w-100 mb-3 text-center">
+            <img src="${photo.url}" alt="${photo.name}" class="img-fluid rounded shadow" style="max-height: 320px; object-fit: contain;">
+        </div>
+        <div class="w-100">
+            <h5 class="mb-2">${photo.name}</h5>
+            <p class="mb-1"><strong>Taille :</strong> ${formatBytes(photo.size)}</p>
+            <p class="mb-3"><strong>Date :</strong> ${formatDate(photo.mtime)}</p>
+            <div class="d-flex flex-column flex-sm-row gap-2">
+                <button type="button" class="btn btn-danger flex-grow-1" id="usbDeleteBtn">
+                    <i class="fas fa-trash me-2"></i>Supprimer
+                </button>
+                <button type="button" class="btn btn-outline-light flex-grow-1" id="usbKeepBtn">
+                    <i class="fas fa-check me-2"></i>Conserver
+                </button>
+            </div>
+        </div>
+    `;
+
+    const deleteBtn = document.getElementById('usbDeleteBtn');
+    if (deleteBtn) {
+        deleteBtn.addEventListener('click', () => confirmDeleteUsbPhoto(photo.name));
+    }
+
+    const keepBtn = document.getElementById('usbKeepBtn');
+    if (keepBtn) {
+        keepBtn.addEventListener('click', closeUsbPreview);
+    }
+}
+
+function highlightSelectedUsb(name) {
+    document.querySelectorAll('#usbPhotosContainer .usb-photo-item').forEach(item => {
+        item.classList.toggle('active', !!name && item.dataset.name === name);
+    });
+}
+
+function closeUsbPreview() {
+    selectedUsbPhotoName = null;
+    updateUsbPreview(null);
+    highlightSelectedUsb(null);
+}
+
+async function confirmDeleteUsbPhoto(name) {
+    if (!confirm('Êtes-vous sûr ?')) {
+        return;
+    }
+    try {
+        const response = await fetch(`/usb/photo/${encodeURIComponent(name)}`, {
+            method: 'DELETE',
+            headers: {
+                'Content-Type': 'application/json',
+            }
+        });
+        const result = await response.json();
+        if (!response.ok || !result.success) {
+            throw new Error(result.error || 'Erreur lors de la suppression');
+        }
+        showToast('Photo supprimée de la clé USB.', 'success');
+        selectedUsbPhotoName = null;
+        await refreshUsbPhotos(true);
+    } catch (error) {
+        console.error('Erreur lors de la suppression USB:', error);
+        showToast(error.message || 'Erreur lors de la suppression', 'error');
+    }
+}
+
+function formatBytes(bytes) {
+    if (!Number.isFinite(bytes)) {
+        return '-';
+    }
+    const units = ['o', 'Ko', 'Mo', 'Go'];
+    let index = 0;
+    let value = bytes;
+    while (value >= 1024 && index < units.length - 1) {
+        value /= 1024;
+        index += 1;
+    }
+    return `${value.toFixed(value < 10 && index > 0 ? 1 : 0)} ${units[index]}`;
+}
+
+function formatDate(timestamp) {
+    try {
+        return new Date(timestamp * 1000).toLocaleString('fr-FR');
+    } catch (error) {
+        return '-';
     }
 }
 

--- a/templates/review.html
+++ b/templates/review.html
@@ -63,78 +63,42 @@
     <div class="action-buttons">
         <div class="row g-2 g-md-3 justify-content-center">
             {% if config.effect_enabled %}
-            <div class="col">
+            <div class="col-6 col-md-3">
                 <button class="btn btn-warning w-100 btn-review" onclick="applyEffect()">
                     <i class="fas fa-magic"></i>
                     <span>Effet</span>
                 </button>
             </div>
-            {% if config.printer_enabled %}
-            <div class="col">
-                <button class="btn btn-success w-100 btn-review" onclick="printPhoto()">
-                    <i class="fas fa-print"></i>
-                    <span>Imprimer</span>
+            {% endif %}
+            <div class="col-6 col-md-3">
+                <button class="btn btn-usb w-100 btn-review" onclick="savePhotoToUsb(this)">
+                    <i class="fas fa-save"></i>
+                    <span>Sauvegarder</span>
                 </button>
             </div>
-            {% endif %}
-            <div class="col">
+            <div class="col-6 col-md-3">
                 <a href="{{ url_for('index') }}" class="btn btn-primary w-100 btn-review">
                     <i class="fas fa-redo"></i>
                     <span>Reprendre</span>
                 </a>
             </div>
-            <div class="col">
+            <div class="col-6 col-md-3">
                 <button class="btn btn-danger w-100 btn-review" onclick="deletePhoto()">
                     <i class="fas fa-trash"></i>
                     <span>Supprimer</span>
                 </button>
             </div>
-            {% else %}
-            {% if config.printer_enabled %}
-                <div class="col-4">
-                    <button class="btn btn-success w-100 btn-review" onclick="printPhoto()">
-                        <i class="fas fa-print"></i>
-                        <span>Imprimer</span>
-                    </button>
-                </div>
-                <div class="col-4">
-                    <a href="{{ url_for('index') }}" class="btn btn-primary w-100 btn-review">
-                        <i class="fas fa-redo"></i>
-                        <span>Reprendre</span>
-                    </a>
-                </div>
-                <div class="col-4">
-                    <button class="btn btn-danger w-100 btn-review" onclick="deletePhoto()">
-                        <i class="fas fa-trash"></i>
-                        <span>Supprimer</span>
-                    </button>
-                </div>
-            {% else %}
-                <div class="col-6">
-                    <a href="{{ url_for('index') }}" class="btn btn-primary w-100 btn-review">
-                        <i class="fas fa-redo"></i>
-                        <span>Reprendre</span>
-                    </a>
-                </div>
-                <div class="col-6">
-                    <button class="btn btn-danger w-100 btn-review" onclick="deletePhoto()">
-                        <i class="fas fa-trash"></i>
-                        <span>Supprimer</span>
-                    </button>
-                </div>
-            {% endif %}
-            {% endif %}
         </div>
     </div>
 </div>
 
-<!-- Overlay d'impression en plein écran -->
-<div id="printOverlay" class="d-none" style="position: fixed; top: 0; left: 0; width: 100%; height: 100%; background-color: rgba(0,0,0,0.8); z-index: 9999; display: flex; align-items: center; justify-content: center;">
-    <div class="text-center text-white">
+<!-- Overlay de sauvegarde en plein écran -->
+<div id="saveOverlay" class="d-none" style="position: fixed; top: 0; left: 0; width: 100%; height: 100%; background-color: rgba(0,0,0,0.8); z-index: 9999; display: flex; align-items: center; justify-content: center;">
+    <div class="text-center text-white" id="saveOverlayContent">
         <div class="mb-4">
             <i class="fas fa-spinner fa-spin" style="font-size: 4rem;"></i>
         </div>
-        <h2 class="mb-3">Impression en cours...</h2>
+        <h2 class="mb-3">Sauvegarde en cours...</h2>
         <p class="mb-0">Veuillez patienter</p>
     </div>
 </div>
@@ -191,85 +155,72 @@
 
 {% block scripts %}
 <script>
-async function printPhoto() {
-    const printBtn = event.target;
-    const originalContent = printBtn.innerHTML;
-    const overlay = document.getElementById('printOverlay');
-    
-    // Désactiver le bouton et afficher l'overlay
-    printBtn.disabled = true;
-    printBtn.innerHTML = '<i class="fas fa-spinner fa-spin me-2"></i>Impression...';
+async function savePhotoToUsb(button) {
+    const overlay = document.getElementById('saveOverlay');
+    const overlayContent = document.getElementById('saveOverlayContent');
+    const originalContent = button.innerHTML;
+
+    button.disabled = true;
+    button.innerHTML = '<i class="fas fa-spinner fa-spin me-2"></i>Sauvegarde...';
+
+    overlayContent.innerHTML = `
+        <div class="mb-4">
+            <i class="fas fa-spinner fa-spin" style="font-size: 4rem;"></i>
+        </div>
+        <h2 class="mb-3">Sauvegarde en cours...</h2>
+        <p class="mb-0">Veuillez patienter</p>
+    `;
     overlay.classList.remove('d-none');
     overlay.style.display = 'flex';
-    
+
     try {
-        const response = await fetch('/print_photo', {
+        const response = await fetch('/save_photo_usb', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
             }
         });
-        
+
         const result = await response.json();
-        
+
         if (result.success) {
-            // Succès de l'impression - modifier le contenu de l'overlay
-            overlay.innerHTML = 
-                '<div class="text-center text-white">' +
-                '<div class="mb-4">' +
-                '<i class="fas fa-check-circle" style="font-size: 4rem; color: #28a745;"></i>' +
-                '</div>' +
-                '<h2 class="mb-3">Impression terminée !</h2>' +
-                '<p class="mb-0">Redirection en cours...</p>' +
-                '</div>';
-            
-            // Rediriger vers l'accueil après 3 secondes
+            overlayContent.innerHTML = `
+                <div class="mb-4">
+                    <i class="fas fa-check-circle" style="font-size: 4rem; color: #4caf50;"></i>
+                </div>
+                <h2 class="mb-3">Sauvegarde terminée !</h2>
+                <p class="mb-0">Fichier copié sur la clé USB.</p>
+            `;
+            if (result.path) {
+                showToast(`Photo sauvegardée sur la clé USB : ${result.path}`, 'success');
+            }
+
             setTimeout(() => {
-                window.location.href = '/';
-            }, 3000);
-            
-        } else if (result.error_type === 'no_paper') {
-            // Cas spécifique du manque de papier - rediriger immédiatement vers l'index
-            overlay.innerHTML = 
-                '<div class="text-center text-white">' +
-                '<div class="mb-4">' +
-                '<i class="fas fa-exclamation-triangle" style="font-size: 4rem; color: #ffc107;"></i>' +
-                '</div>' +
-                '<h2 class="mb-3">Plus de papier !</h2>' +
-                '<p class="mb-0">Redirection en cours...</p>' +
-                '</div>';
-            
-            // Rediriger vers l'accueil avec paramètre pour afficher l'alerte
-            setTimeout(() => {
-                window.location.href = '/?show_paper_alert=1';
+                overlay.classList.add('d-none');
+                overlay.style.display = 'none';
             }, 2000);
-            
         } else {
-            throw new Error(result.error || 'Erreur d\'impression');
+            throw new Error(result.error || 'Erreur de sauvegarde');
         }
-        
     } catch (error) {
-        console.error('Erreur lors de l\'impression:', error);
-        
-        // Afficher l'erreur dans l'overlay
-        overlay.innerHTML = 
-            '<div class="text-center text-white">' +
-            '<div class="mb-4">' +
-            '<i class="fas fa-exclamation-triangle" style="font-size: 4rem; color: #dc3545;"></i>' +
-            '</div>' +
-            '<h2 class="mb-3">Erreur d\'impression</h2>' +
-            '<p class="mb-3">' + error.message + '</p>' +
-            '<button class="btn btn-light" onclick="closeOverlay()">Fermer</button>' +
-            '</div>';
-        
-        // Réactiver le bouton
-        printBtn.disabled = false;
-        printBtn.innerHTML = originalContent;
+        console.error('Erreur lors de la sauvegarde USB:', error);
+        overlayContent.innerHTML = `
+            <div class="mb-4">
+                <i class="fas fa-exclamation-triangle" style="font-size: 4rem; color: #dc3545;"></i>
+            </div>
+            <h2 class="mb-3">Erreur de sauvegarde</h2>
+            <p class="mb-3">${error.message}</p>
+            <button class="btn btn-light" onclick="closeSaveOverlay()">Fermer</button>
+        `;
+        showToast(error.message || 'Erreur de sauvegarde', 'error');
+    } finally {
+        button.disabled = false;
+        button.innerHTML = originalContent;
     }
 }
 
-function closeOverlay() {
-    const overlay = document.getElementById('printOverlay');
+function closeSaveOverlay() {
+    const overlay = document.getElementById('saveOverlay');
     overlay.classList.add('d-none');
     overlay.style.display = 'none';
 }


### PR DESCRIPTION
## Résumé
- ajout du module `storage_usb` pour détecter les clés USB, gérer le dossier SimpleBooth et exposer les opérations de sauvegarde, liste et suppression
- remplacement du bouton d'impression par la sauvegarde USB sur l'écran de révision avec toasts en français
- ajout du bouton « Gérer USB » et d'une modale de gestion (aperçu, suppression, rafraîchissement) sur l'écran principal
- mise à jour du style (boutons bleus partagés) et documentation `README_USB.md`

## Tests
- `python -m compileall app.py storage_usb.py`


------
https://chatgpt.com/codex/tasks/task_e_68ceae985ee4832a98ce6d6eaa070d58