### PR TITLE
Évite le repli USB quand aucune caméra n'est détectée

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -221,10 +221,10 @@ function initCamera() {
 }
 
 function showCameraError() {
-    document.getElementById('videoContainer').innerHTML = 
+    document.getElementById('videoContainer').innerHTML =
         '<div class="alert alert-warning m-3">' +
         '<i class="fas fa-exclamation-triangle me-2"></i>' +
-        'Impossible d\'accéder à la caméra. Vérifiez que libcamera est installé et que la caméra est connectée.' +
+        'Impossible d\'accéder à la caméra. Vérifiez la configuration (USB ou libcamera) et la connexion de la caméra.' +
         '</div>';
 }
 


### PR DESCRIPTION
## Summary
- désactive le repli automatique vers une caméra USB lorsqu'aucun périphérique n'est détecté
- journalise et remonte une erreur explicite de détection USB pour clarifier l'absence de périphérique

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68ced3ba0bc0832abd64e2326291c192