### PR TITLE
Make camera preview fullscreen with minimal controls

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -3,24 +3,101 @@
 {% block title %}Photobooth{% endblock %}
 
 {% block content %}
-<div class="container-fluid p-3" style="height: 100vh; overflow: hidden; position: fixed; top: 0; left: 0; right: 0; bottom: 0; background-color: #1a1a1a;">
+<div class="camera-fullscreen" id="videoContainer">
     <style>
-    /* Ajustements spécifiques pour les petits écrans 800x480 */
-    @media (max-width: 800px) and (max-height: 480px) {
-        #videoContainer {
-            height: calc(100vh - 1rem);
-            width: calc(100vw - 1rem);
-        }
+    body {
+        background: #000 !important;
+    }
 
-        #cameraVideo,
-        #cameraFallbackImage {
-            max-width: calc(100vw - 1rem);
-            max-height: calc(100vh - 1rem);
+    .container-fluid {
+        padding: 0 !important;
+    }
+
+    .camera-fullscreen {
+        position: fixed;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: #000;
+        overflow: hidden;
+    }
+
+    .camera-video-wrapper {
+        position: relative;
+        width: 100vw;
+        height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: #000;
+    }
+
+    #cameraVideo,
+    #cameraFallbackImage {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        background: #000;
+    }
+
+    .camera-controls {
+        position: absolute;
+        bottom: 3rem;
+        left: 50%;
+        transform: translateX(-50%);
+        display: flex;
+        gap: 1.5rem;
+        z-index: 10;
+    }
+
+    #captureBtn {
+        border-radius: 50%;
+        width: 5rem;
+        height: 5rem;
+        padding: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 2rem;
+        box-shadow: 0 4px 15px rgba(0,0,0,0.3);
+    }
+
+    #usbManagerBtn {
+        border-radius: 1.5rem;
+        padding: 1rem 1.5rem;
+        font-size: 1.1rem;
+        box-shadow: 0 4px 15px rgba(0,0,0,0.3);
+    }
+
+    .camera-error-banner {
+        position: absolute;
+        top: 2rem;
+        left: 50%;
+        transform: translateX(-50%);
+        max-width: 90vw;
+        z-index: 20;
+    }
+
+    .countdown {
+        position: fixed;
+    }
+
+    @media (max-width: 800px) {
+        .camera-controls {
+            bottom: 2rem;
+            gap: 1rem;
         }
 
         #captureBtn {
-            font-size: 1.2rem;
-            padding: 8px 16px;
+            width: 4rem;
+            height: 4rem;
+            font-size: 1.5rem;
+        }
+
+        #usbManagerBtn {
+            padding: 0.75rem 1.25rem;
+            font-size: 1rem;
         }
     }
 
@@ -47,87 +124,60 @@
         height: 100%;
     }
     </style>
-    <!-- Conteneur vidéo avec marges élégantes -->
-    <div class="video-container position-relative d-flex align-items-center justify-content-center" id="videoContainer" style="height: calc(100vh - 2rem); width: calc(100vw - 2rem);">
-        <div id="cameraInterface" class="w-100 h-100 d-flex flex-column gap-3">
-            <div id="cameraErrorBanner" class="alert alert-danger d-none d-flex flex-column flex-lg-row gap-3 align-items-start" role="alert">
-                <div class="flex-grow-1">
-                    <strong>Impossible d'accéder à la caméra.</strong>
-                    <div id="cameraErrorBannerText" class="mt-2"></div>
-                    <div id="cameraErrorBannerDetails" class="small text-muted mt-2"></div>
-                </div>
-                <div class="d-flex flex-column gap-2">
-                    <button class="btn btn-outline-light btn-sm" id="cameraRetryButton">
-                        <i class="fas fa-sync-alt me-2"></i>
-                        Re-tester l'accès caméra
-                    </button>
-                    <button class="btn btn-outline-warning btn-sm" id="cameraDiagnosticButton">
-                        <i class="fas fa-stethoscope me-2"></i>
-                        Diagnostic caméra
-                    </button>
-                </div>
-            </div>
 
-            <div class="d-flex flex-wrap align-items-center justify-content-between gap-3">
-                <div class="d-flex align-items-center gap-2 text-white">
-                    <i class="fas fa-video"></i>
-                    <label for="cameraDeviceSelect" class="mb-0">Caméra</label>
-                    <select id="cameraDeviceSelect" class="form-select form-select-sm" style="min-width: 220px;"></select>
-                </div>
-                <div class="text-white-50 small" id="cameraStatusHint">
-                    Plan A : WebRTC / Plan B : MJPEG Picamera2
-                </div>
-            </div>
-
-            <div id="cameraVideoWrapper" class="position-relative flex-grow-1 d-flex align-items-center justify-content-center">
-                <video id="cameraVideo"
-                       autoplay
-                       playsinline
-                       muted
-                       class="w-100 h-100"
-                       style="max-width: calc(100vw - 2rem); max-height: calc(100vh - 2rem); object-fit: contain; background-color: #000; border-radius: 15px; box-shadow: 0 8px 32px rgba(0,0,0,0.5);">
-                </video>
-                <img id="cameraFallbackImage"
-                     class="d-none w-100 h-100"
-                     style="max-width: calc(100vw - 2rem); max-height: calc(100vh - 2rem); object-fit: contain; background-color: #000; border-radius: 15px; box-shadow: 0 8px 32px rgba(0,0,0,0.5);"
-                     alt="Flux MJPEG caméra">
-                <span id="planBBadge" class="badge bg-warning text-dark position-absolute top-0 start-0 m-3 d-none">Plan B (MJPEG)</span>
-            </div>
-        </div>
-
-    <!-- Countdown overlay -->
-    <div class="countdown d-none position-absolute top-50 start-50 translate-middle" id="countdown"></div>
-
-    <!-- Flash blanc pour la prise de photo -->
-        <div class="flash-overlay d-none position-fixed top-0 start-0 w-100 h-100" id="flashOverlay" 
-             style="background-color: white; z-index: 15; display: flex; align-items: center; justify-content: center;">
-            <div style="font-size: 8rem; font-weight: bold; color: black; text-shadow: none;">CHEESE!</div>
-        </div>
-        
-        <!-- Bouton capture en overlay -->
-        <div class="position-absolute bottom-0 start-50 translate-middle-x mb-4" style="z-index: 5;">
-            <div class="d-flex flex-column flex-md-row align-items-center gap-3">
-                <button id="captureBtn" class="btn btn-danger btn-lg px-5 py-3" onclick="capturePhoto()"
-                        style="font-size: 1.5rem; border-radius: 50px; box-shadow: 0 4px 15px rgba(0,0,0,0.3);">
-                    <i class="fas fa-camera fa-2x"></i>
-                </button>
-                <button id="usbManagerBtn" class="btn btn-usb btn-lg px-4 py-3" onclick="openUsbManager()"
-                        style="font-size: 1.1rem; border-radius: 20px; box-shadow: 0 4px 15px rgba(0,0,0,0.3);">
-                    <i class="fas fa-usb me-2"></i>
-                    Gérer USB
-                </button>
-            </div>
+    <div id="cameraErrorBanner" class="alert alert-danger d-none camera-error-banner" role="alert">
+        <div class="fw-bold">Impossible d'accéder à la caméra.</div>
+        <div id="cameraErrorBannerText" class="mt-2"></div>
+        <div id="cameraErrorBannerDetails" class="small text-muted mt-2"></div>
+        <div class="d-flex gap-2 mt-3">
+            <button class="btn btn-outline-light btn-sm" id="cameraRetryButton">
+                <i class="fas fa-sync-alt me-2"></i>
+                Réessayer
+            </button>
+            <button class="btn btn-outline-warning btn-sm" id="cameraDiagnosticButton">
+                <i class="fas fa-stethoscope me-2"></i>
+                Diagnostic
+            </button>
         </div>
     </div>
 
-    <!-- Alerte manque de papier -->
-    <div class="position-fixed top-0 start-50 translate-middle-x mt-3" style="z-index: 20; width: 90%; max-width: 500px;">
-        <div class="alert alert-warning d-none d-flex align-items-center" id="paper-alert" style="border-radius: 15px; box-shadow: 0 4px 15px rgba(0,0,0,0.3);">
-            <i class="fas fa-exclamation-triangle me-2"></i>
-            <div>
-                <strong>Attention !</strong><br>
-                <small>Vérifiez le papier de l'imprimante avant de prendre une photo</small>
-            </div>
+    <div id="cameraVideoWrapper" class="camera-video-wrapper">
+        <video id="cameraVideo"
+               autoplay
+               playsinline
+               muted>
+        </video>
+        <img id="cameraFallbackImage"
+             class="d-none"
+             alt="Flux MJPEG caméra">
+        <span id="planBBadge" class="badge bg-warning text-dark position-absolute top-0 start-0 m-3 d-none">Plan B (MJPEG)</span>
+    </div>
+
+    <div class="camera-controls">
+        <button id="captureBtn" class="btn btn-danger btn-lg" onclick="capturePhoto()">
+            <i class="fas fa-camera"></i>
+        </button>
+        <button id="usbManagerBtn" class="btn btn-usb btn-lg" onclick="openUsbManager()">
+            <i class="fas fa-usb me-2"></i>
+            Clé USB
+        </button>
+    </div>
+</div>
+
+<div class="countdown d-none position-fixed top-50 start-50 translate-middle" id="countdown"></div>
+
+<div class="flash-overlay d-none position-fixed top-0 start-0 w-100 h-100" id="flashOverlay"
+     style="background-color: white; z-index: 15; display: flex; align-items: center; justify-content: center;">
+    <div style="font-size: 8rem; font-weight: bold; color: black; text-shadow: none;">CHEESE!</div>
+</div>
+
+<!-- Alerte manque de papier -->
+<div class="position-fixed top-0 start-50 translate-middle-x mt-3" style="z-index: 20; width: 90%; max-width: 500px;">
+    <div class="alert alert-warning d-none d-flex align-items-center" id="paper-alert" style="border-radius: 15px; box-shadow: 0 4px 15px rgba(0,0,0,0.3);">
+        <i class="fas fa-exclamation-triangle me-2"></i>
+        <div>
+            <strong>Attention !</strong><br>
+            <small>Vérifiez le papier de l'imprimante avant de prendre une photo</small>
         </div>
     </div>
 </div>
@@ -252,7 +302,6 @@ document.addEventListener('DOMContentLoaded', async () => {
             errorBanner: document.getElementById('cameraErrorBanner'),
             errorBannerText: document.getElementById('cameraErrorBannerText'),
             errorBannerDetails: document.getElementById('cameraErrorBannerDetails'),
-            deviceSelect: document.getElementById('cameraDeviceSelect'),
             diagnosticsModal: document.getElementById('cameraDiagnosticModal'),
             diagnosticsDevicesList: document.getElementById('cameraDiagnosticDevices'),
             diagnosticsHealthPre: document.getElementById('cameraHealthDump'),
@@ -289,7 +338,7 @@ function capturePhoto() {
     
     // Désactiver le bouton
     captureBtn.disabled = true;
-    captureBtn.innerHTML = '<i class="fas fa-spinner fa-spin fa-2x"></i>';
+    captureBtn.innerHTML = '<i class="fas fa-spinner fa-spin"></i>';
     
     // Démarrer le compte à rebours
     let timeLeft = parseInt('{{ timer }}');


### PR DESCRIPTION
## Summary
- stretch the camera interface to fill the entire viewport with a black background
- keep only the capture and USB buttons as floating controls over the live preview
- tweak the capture button spinner to fit the new compact control layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d01ff4456c832a8279e7e25007a38e