### PR TITLE
Add script to fix USB permissions

### DIFF
--- a/fix_usb_permissions.sh
+++ b/fix_usb_permissions.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MOUNT_PATH="/media/steeve/31 GB Volume"
+TARGET_USER=$(id -un)
+TARGET_GROUP=$(id -gn)
+
+if [[ $EUID -ne 0 ]]; then
+  echo "[ERREUR] Ce script doit être exécuté avec les privilèges administrateur (ex: sudo)." >&2
+  exit 1
+fi
+
+if [[ ! -d "$MOUNT_PATH" ]]; then
+  echo "[ERREUR] Le chemin '$MOUNT_PATH' n'existe pas. Vérifiez que la clé USB est bien montée." >&2
+  exit 1
+fi
+
+echo "Réattribution du dossier '$MOUNT_PATH' à $TARGET_USER:$TARGET_GROUP ..."
+chown -R "$TARGET_USER:$TARGET_GROUP" "$MOUNT_PATH"
+
+echo "Application des droits de lecture/écriture/exécution pour l'utilisateur ..."
+chmod -R u+rwX "$MOUNT_PATH"
+
+echo "Nettoyage des attributs d'accès bloquants (facultatif) ..."
+find "$MOUNT_PATH" -type f -exec chmod u+rw {} +
+
+sync
+
+echo "Permissions mises à jour avec succès. Vous ne devriez plus voir le message d'erreur."


### PR DESCRIPTION
## Summary
- add a Bash script that reassigns ownership and permissions for the USB mount point
- include safety checks ensuring the script runs with sudo and that the mount path exists

## Testing
- not run (permissions script requires sudo)

------
https://chatgpt.com/codex/tasks/task_e_68d56b34bfb0832a865f8a872d76df6a