### PR TITLE
Fix Plan B capture by fetching MJPEG frame

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -370,11 +370,17 @@ function capturePhoto() {
 
 async function takePicture() {
     try {
+        const payload = {
+            planB: !!window.SimpleBoothCameraClient?.isPlanBActive,
+            cameraServerBase: window.SimpleBoothCameraClient?.cameraServerBase || null,
+        };
+
         const response = await fetch('/capture', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
-            }
+            },
+            body: JSON.stringify(payload),
         });
         
         const result = await response.json();


### PR DESCRIPTION
## Summary
- add a Plan B MJPEG frame fetch helper and default camera server URL so /capture can grab a frame even when the local stream is unavailable
- fall back to the Plan B frame whenever the UI indicates the MJPEG server is in use and persist the captured frame for downstream flows
- update the capture request to send Plan B context from the browser

## Testing
- python -m compileall app.py templates/index.html

------
https://chatgpt.com/codex/tasks/task_e_68d56e3dbb98832a9ce0640f007277d2