### PR TITLE
Replace reprint button with save button

### DIFF
--- a/app.py
+++ b/app.py
@@ -710,9 +710,9 @@ def download_photo(filename):
         flash(f'Erreur lors du téléchargement: {str(e)}', 'error')
         return redirect(url_for('admin'))
 
-@app.route('/admin/reprint_photo/<filename>', methods=['POST'])
-def reprint_photo(filename):
-    """Réimprimer une photo spécifique"""
+@app.route('/admin/save_photo/<filename>', methods=['POST'])
+def save_photo(filename):
+    """Sauvegarder une photo spécifique"""
     try:
         # Chercher la photo dans les deux dossiers
         photo_path = None
@@ -748,18 +748,18 @@ def reprint_photo(filename):
             result = subprocess.run(cmd, capture_output=True, text=True, cwd=os.path.dirname(os.path.abspath(__file__)))
             
             if result.returncode == 0:
-                flash('Photo réimprimée avec succès!', 'success')
+                flash('Photo sauvegardée avec succès!', 'success')
             else:
                 error_msg = result.stderr.strip() if result.stderr else 'Erreur inconnue'
                 if 'ModuleNotFoundError' in error_msg and 'escpos' in error_msg:
                     flash('Module escpos manquant. Installez-le avec: pip install python-escpos', 'error')
                 else:
-                    flash(f'Erreur d\'impression: {error_msg}', 'error')
+                    flash(f'Erreur lors de la sauvegarde: {error_msg}', 'error')
         else:
             flash('Photo introuvable', 'error')
     except Exception as e:
-        flash(f'Erreur lors de la réimpression: {str(e)}', 'error')
-    
+        flash(f'Erreur lors de la sauvegarde: {str(e)}', 'error')
+
     return redirect(url_for('admin'))
 
 @app.route('/api/slideshow')

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -696,9 +696,9 @@
                         </button>
                     </div>
                     <div class="col-4">
-                        <button type="button" class="btn btn-success w-100" id="reprintBtn">
-                            <i class="fas fa-print me-2"></i>
-                            Réimprimer
+                        <button type="button" class="btn btn-success w-100" id="saveBtn">
+                            <i class="fas fa-save me-2"></i>
+                            Sauvegarder
                         </button>
                     </div>
                 </div>
@@ -842,12 +842,12 @@ function openPhotoModal(element) {
         window.location.href = `{{ url_for('download_photo', filename='') }}${filename}`;
     };
     
-    document.getElementById('reprintBtn').onclick = function() {
-        if (confirm('Voulez-vous vraiment réimprimer cette photo ?')) {
+    document.getElementById('saveBtn').onclick = function() {
+        if (confirm('Voulez-vous vraiment sauvegarder cette photo ?')) {
             // Créer un formulaire pour la requête POST
             const form = document.createElement('form');
             form.method = 'POST';
-            form.action = `{{ url_for('reprint_photo', filename='') }}${filename}`;
+            form.action = `{{ url_for('save_photo', filename='') }}${filename}`;
             document.body.appendChild(form);
             form.submit();
         }


### PR DESCRIPTION
## Summary
- rename the admin photo modal action button from reprint to save, including icon, label, and element id
- update the Flask route and related messaging to use the new save_photo endpoint

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ded1ada634832a83cb308d92e95bac