### PR TITLE
Force Chromium media permissions in kiosk mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,17 @@ Un script `setup.sh` est fourni pour automatiser l'ensemble du processus sur un 
     - Installer les dépendances Python de `requirements.txt` dans cet environnement.
     - Creer un mode kiosk automatique au demarrage du systeme.
 
+    Le mode kiosk démarre Chromium en plein écran avec les options suivantes pour éviter toute demande manuelle d'autorisation caméra/micro :
+
+    ```bash
+    chromium-browser --kiosk --no-sandbox --noerrdialogs --disable-infobars \
+      --use-fake-ui-for-media-stream \
+      --autoplay-policy=no-user-gesture-required \
+      http://localhost:5000
+    ```
+
+    ⚠️ **Important :** ces options acceptent automatiquement l'accès aux périphériques audio/vidéo. Ne les activez pas sur une machine exposée à Internet.
+
 #### Méthode 2 : Installation manuelle
 
 Suivez ces étapes pour une installation manuelle.

--- a/setup.sh
+++ b/setup.sh
@@ -310,6 +310,8 @@ exec $CHROMIUM_PKG --kiosk --no-sandbox --disable-infobars \
   --no-default-browser-check \
   --no-first-run \
   --disable-component-update \
+  --use-fake-ui-for-media-stream \
+  --autoplay-policy=no-user-gesture-required \
   --lang=fr \
   http://localhost:5000
 EOF


### PR DESCRIPTION
## Summary
- add Chromium startup flags in the kiosk launch script to auto-approve camera and microphone access while loading the app
- document the kiosk launch command and warn against using it on internet-exposed machines

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68ded55e9c24832abb247696297ad8cf