### PR TITLE
Add Raspberry Pi camera service with WebRTC fallback support

### DIFF
--- a/camera-service.service
+++ b/camera-service.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=SimpleBooth Camera Service
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/home/pi/camera_service
+ExecStart=/usr/bin/python3 /home/pi/camera_service/app.py
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/camera_service/app.py
+++ b/camera_service/app.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Camera service exposing health and snapshot endpoints for the photobooth."""
+
+from __future__ import annotations
+
+import io
+import logging
+import threading
+from contextlib import contextmanager
+from datetime import datetime
+
+from flask import Flask, Response, jsonify
+from flask_cors import CORS
+
+try:
+    from picamera2 import Picamera2
+except Exception as exc:  # pragma: no cover - dependency missing on CI
+    Picamera2 = None  # type: ignore[assignment]
+    PICAMERA_IMPORT_ERROR = exc
+else:
+    PICAMERA_IMPORT_ERROR = None
+
+LOGGER = logging.getLogger("camera_service")
+logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
+
+app = Flask(__name__)
+CORS(app, resources={r"/*": {"origins": "http://localhost:5000"}})
+
+_CAMERA_LOCK = threading.Lock()
+
+
+class CameraUnavailableError(RuntimeError):
+    """Raised when the camera cannot be acquired."""
+
+
+@contextmanager
+def open_camera() -> Picamera2:
+    if Picamera2 is None:
+        raise CameraUnavailableError(
+            "Picamera2 non disponible: installez python3-picamera2 et vérifiez les permissions"
+        )
+
+    if not _CAMERA_LOCK.acquire(timeout=4):
+        raise CameraUnavailableError("Caméra occupée par un autre processus")
+
+    camera = None
+    try:
+        camera = Picamera2()
+        still_config = camera.create_still_configuration()
+        camera.configure(still_config)
+        camera.start()
+        yield camera
+    finally:
+        if camera is not None:
+            try:
+                camera.stop()
+            except Exception:  # pragma: no cover - best effort cleanup
+                LOGGER.exception("Erreur lors de l'arrêt de la caméra")
+            try:
+                camera.close()
+            except Exception:  # pragma: no cover
+                LOGGER.exception("Erreur lors de la fermeture de la caméra")
+        _CAMERA_LOCK.release()
+
+
+def capture_jpeg_bytes() -> bytes:
+    with open_camera() as camera:
+        buffer = io.BytesIO()
+        camera.capture_file(buffer, format="jpeg")
+        return buffer.getvalue()
+
+
+def check_camera_ready() -> tuple[bool, str]:
+    if PICAMERA_IMPORT_ERROR is not None:
+        return False, f"Impossible d'importer Picamera2: {PICAMERA_IMPORT_ERROR}"
+
+    try:
+        with open_camera():
+            return True, "ready"
+    except CameraUnavailableError as exc:
+        return False, str(exc)
+    except Exception as exc:  # pragma: no cover - defensive programming
+        LOGGER.exception("Erreur lors du test caméra")
+        return False, f"Erreur caméra: {exc}"
+
+
+@app.route("/health", methods=["GET"])
+def health() -> Response:
+    ok, detail = check_camera_ready()
+    status_code = 200 if ok else 503
+    payload = {"ok": ok}
+    if ok:
+        payload["camera"] = detail
+    else:
+        payload["error"] = detail
+    return jsonify(payload), status_code
+
+
+@app.route("/snapshot", methods=["GET"])
+def snapshot() -> Response:
+    try:
+        jpeg_bytes = capture_jpeg_bytes()
+    except CameraUnavailableError as exc:
+        LOGGER.warning("Caméra indisponible: %s", exc)
+        return jsonify({"ok": False, "error": str(exc)}), 503
+    except TimeoutError as exc:  # pragma: no cover - safeguard
+        LOGGER.error("Timeout caméra: %s", exc)
+        return jsonify({"ok": False, "error": "Capture expirée"}), 503
+    except Exception as exc:  # pragma: no cover
+        LOGGER.exception("Erreur lors de la capture")
+        return jsonify({"ok": False, "error": str(exc)}), 503
+
+    headers = {
+        "Content-Type": "image/jpeg",
+        "Content-Disposition": f"inline; filename=snapshot_{datetime.now():%Y%m%d_%H%M%S}.jpg",
+        "Cache-Control": "no-store, max-age=0",
+    }
+    return Response(jpeg_bytes, headers=headers)
+
+
+def main() -> None:
+    app.run(host="0.0.0.0", port=8080, debug=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/camera_service/requirements.txt
+++ b/camera_service/requirements.txt
@@ -1,0 +1,3 @@
+flask>=3
+flask-cors>=4
+picamera2

--- a/templates/index.html
+++ b/templates/index.html
@@ -41,6 +41,13 @@
         background: #000;
     }
 
+    #cameraStatusChip {
+        position: absolute;
+        top: 1rem;
+        right: 1rem;
+        z-index: 20;
+    }
+
     .camera-controls {
         position: absolute;
         bottom: 3rem;
@@ -125,8 +132,8 @@
     }
     </style>
 
-    <div id="cameraErrorBanner" class="alert alert-danger d-none camera-error-banner" role="alert">
-        <div class="fw-bold">Impossible d'accéder à la caméra.</div>
+    <div id="cameraErrorBanner" class="alert alert-warning d-none camera-error-banner" role="alert">
+        <div id="cameraErrorBannerTitle" class="fw-bold">Statut caméra</div>
         <div id="cameraErrorBannerText" class="mt-2"></div>
         <div id="cameraErrorBannerDetails" class="small text-muted mt-2"></div>
         <div class="d-flex gap-2 mt-3">
@@ -149,8 +156,9 @@
         </video>
         <img id="cameraFallbackImage"
              class="d-none"
-             alt="Flux MJPEG caméra">
-        <span id="planBBadge" class="badge bg-warning text-dark position-absolute top-0 start-0 m-3 d-none">Plan B (MJPEG)</span>
+             alt="Capture système (8080)">
+        <span id="planBBadge" class="badge bg-warning text-dark position-absolute top-0 start-0 m-3 d-none">Capture système (8080)</span>
+        <span id="cameraStatusChip" class="badge bg-info text-dark">Caméra locale : vérification…</span>
     </div>
 
     <div class="camera-controls">
@@ -285,34 +293,42 @@
 
 {% block scripts %}
 <script type="module">
-import { CameraClient } from "/static/js/cameraClient.js";
+const CAMERA_SERVICE_BASE = window.SIMPLEBOOTH_CAMERA_SERVER
+    || `${window.location.protocol}//${window.location.hostname}:8080`;
 
 let isCapturing = false;
 let usbManagerModal = null;
 let usbPhotos = [];
 let selectedUsbPhotoName = null;
-let cameraClient = null;
+
+let localStream = null;
+let usingBrowserCamera = false;
+let usingHttpFallback = false;
+let lastFallbackUrl = null;
+
+const videoElement = document.getElementById('cameraVideo');
+const fallbackImage = document.getElementById('cameraFallbackImage');
+const planBBadge = document.getElementById('planBBadge');
+const statusChip = document.getElementById('cameraStatusChip');
+const errorBanner = document.getElementById('cameraErrorBanner');
+const errorBannerTitle = document.getElementById('cameraErrorBannerTitle');
+const errorBannerText = document.getElementById('cameraErrorBannerText');
+const errorBannerDetails = document.getElementById('cameraErrorBannerDetails');
+const retryButton = document.getElementById('cameraRetryButton');
+const diagnosticButton = document.getElementById('cameraDiagnosticButton');
+const diagnosticsModal = document.getElementById('cameraDiagnosticModal');
+const diagnosticsDevicesList = document.getElementById('cameraDiagnosticDevices');
+const diagnosticsHealthPre = document.getElementById('cameraHealthDump');
+const diagnosticsTimestamp = document.getElementById('cameraDiagnosticTimestamp');
 
 document.addEventListener('DOMContentLoaded', async () => {
-    try {
-        cameraClient = new CameraClient({
-            videoElement: document.getElementById('cameraVideo'),
-            fallbackImage: document.getElementById('cameraFallbackImage'),
-            planBBadge: document.getElementById('planBBadge'),
-            errorBanner: document.getElementById('cameraErrorBanner'),
-            errorBannerText: document.getElementById('cameraErrorBannerText'),
-            errorBannerDetails: document.getElementById('cameraErrorBannerDetails'),
-            diagnosticsModal: document.getElementById('cameraDiagnosticModal'),
-            diagnosticsDevicesList: document.getElementById('cameraDiagnosticDevices'),
-            diagnosticsHealthPre: document.getElementById('cameraHealthDump'),
-            diagnosticsTimestamp: document.getElementById('cameraDiagnosticTimestamp'),
-            retryButton: document.getElementById('cameraRetryButton'),
-            diagnosticButton: document.getElementById('cameraDiagnosticButton')
-        });
-        await cameraClient.initialise();
-        window.SimpleBoothCameraClient = cameraClient;
-    } catch (error) {
-        console.error('Erreur lors de l\'initialisation de la caméra', error);
+    await initialiseCamera();
+
+    if (retryButton) {
+        retryButton.addEventListener('click', handleCameraRetry);
+    }
+    if (diagnosticButton) {
+        diagnosticButton.addEventListener('click', openCameraDiagnostics);
     }
 
     const refreshBtn = document.getElementById('usbRefreshBtn');
@@ -327,6 +343,395 @@ document.addEventListener('DOMContentLoaded', async () => {
             highlightSelectedUsb(null);
         });
     }
+});
+
+function describeError(error) {
+    if (!error) {
+        return 'Erreur inconnue';
+    }
+    if (typeof error === 'string') {
+        return error;
+    }
+    const name = error.name || error.constructor?.name || 'Erreur';
+    const message = error.message || String(error);
+    return `${name}: ${message}`;
+}
+
+function showCameraMessage(message, details = '', variant = 'warning', title = 'Statut caméra') {
+    if (!errorBanner) {
+        return;
+    }
+
+    errorBanner.classList.remove('d-none', 'alert-danger', 'alert-warning', 'alert-info', 'alert-success');
+    errorBanner.classList.add(`alert-${variant}`);
+
+    if (errorBannerTitle) {
+        errorBannerTitle.textContent = title;
+    }
+    if (errorBannerText) {
+        errorBannerText.textContent = message;
+    }
+    if (errorBannerDetails) {
+        errorBannerDetails.textContent = details || '';
+        errorBannerDetails.classList.toggle('d-none', !details);
+    }
+}
+
+function hideCameraMessage() {
+    if (!errorBanner) {
+        return;
+    }
+    errorBanner.classList.add('d-none');
+    errorBanner.classList.remove('alert-danger', 'alert-warning', 'alert-info', 'alert-success');
+    if (errorBannerText) {
+        errorBannerText.textContent = '';
+    }
+    if (errorBannerDetails) {
+        errorBannerDetails.textContent = '';
+        errorBannerDetails.classList.add('d-none');
+    }
+}
+
+function setStatusChip(text, variant = 'info') {
+    if (!statusChip) {
+        return;
+    }
+    const classesToRemove = ['bg-info', 'bg-success', 'bg-danger', 'bg-warning', 'text-dark', 'text-white'];
+    statusChip.classList.remove(...classesToRemove);
+
+    if (variant === 'success') {
+        statusChip.classList.add('bg-success', 'text-white');
+    } else if (variant === 'danger') {
+        statusChip.classList.add('bg-danger', 'text-white');
+    } else if (variant === 'warning') {
+        statusChip.classList.add('bg-warning', 'text-dark');
+    } else {
+        statusChip.classList.add('bg-info', 'text-dark');
+    }
+
+    statusChip.textContent = text;
+}
+
+async function requestCameraHealth() {
+    const url = `${CAMERA_SERVICE_BASE}/health`;
+    try {
+        const response = await fetch(url, {
+            method: 'GET',
+            mode: 'cors',
+            cache: 'no-store',
+        });
+        let payload = null;
+        try {
+            payload = await response.json();
+        } catch (jsonError) {
+            payload = { ok: false, error: 'Réponse JSON invalide' };
+        }
+        if (!payload || typeof payload !== 'object') {
+            payload = { ok: false, error: 'Réponse inattendue' };
+        }
+        const ok = response.ok && payload && payload.ok === true;
+        return { ok, payload, response };
+    } catch (error) {
+        return {
+            ok: false,
+            payload: { ok: false, error: describeError(error) },
+            response: null,
+        };
+    }
+}
+
+async function updateCameraHealthIndicator() {
+    const result = await requestCameraHealth();
+    if (result.ok) {
+        setStatusChip('Caméra locale prête', 'success');
+    } else {
+        setStatusChip('Caméra locale indisponible', 'danger');
+    }
+    return result;
+}
+
+async function ensureVideoReady(video) {
+    if (!video) {
+        return;
+    }
+    if (video.readyState >= 2 && video.videoWidth && video.videoHeight) {
+        return;
+    }
+    await new Promise((resolve) => {
+        const cleanup = () => {
+            video.removeEventListener('loadeddata', cleanup);
+            video.removeEventListener('loadedmetadata', cleanup);
+            resolve();
+        };
+        video.addEventListener('loadeddata', cleanup, { once: true });
+        video.addEventListener('loadedmetadata', cleanup, { once: true });
+    });
+}
+
+function stopLocalStream() {
+    if (localStream) {
+        localStream.getTracks().forEach((track) => track.stop());
+    }
+    if (videoElement) {
+        videoElement.srcObject = null;
+    }
+    localStream = null;
+    usingBrowserCamera = false;
+}
+
+async function startBrowserCamera() {
+    if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+        throw new Error('API getUserMedia indisponible');
+    }
+
+    stopLocalStream();
+    try {
+        localStream = await navigator.mediaDevices.getUserMedia({
+            video: { facingMode: { ideal: 'environment' } },
+            audio: false,
+        });
+    } catch (error) {
+        localStream = null;
+        throw error;
+    }
+
+    usingBrowserCamera = true;
+    usingHttpFallback = false;
+    if (videoElement) {
+        videoElement.classList.remove('d-none');
+        videoElement.srcObject = localStream;
+        await ensureVideoReady(videoElement);
+    }
+    if (fallbackImage) {
+        fallbackImage.classList.add('d-none');
+    }
+    if (planBBadge) {
+        planBBadge.classList.add('d-none');
+    }
+    hideCameraMessage();
+}
+
+function revokeFallbackUrl() {
+    if (lastFallbackUrl) {
+        URL.revokeObjectURL(lastFallbackUrl);
+        lastFallbackUrl = null;
+    }
+}
+
+function displayFallbackImage(blob) {
+    if (!fallbackImage) {
+        return;
+    }
+    revokeFallbackUrl();
+    lastFallbackUrl = URL.createObjectURL(blob);
+    fallbackImage.src = lastFallbackUrl;
+}
+
+async function fetchSnapshotBlob() {
+    const response = await fetch(`${CAMERA_SERVICE_BASE}/snapshot`, {
+        method: 'GET',
+        mode: 'cors',
+        cache: 'no-store',
+    });
+    if (!response.ok) {
+        const text = await response.text();
+        throw new Error(text || `Erreur ${response.status}`);
+    }
+    return await response.blob();
+}
+
+async function refreshFallbackPreview() {
+    try {
+        const blob = await fetchSnapshotBlob();
+        if (fallbackImage) {
+            fallbackImage.classList.remove('d-none');
+        }
+        if (planBBadge) {
+            planBBadge.classList.remove('d-none');
+        }
+        displayFallbackImage(blob);
+    } catch (error) {
+        const message = "Service caméra indisponible (8080). Vérifie qu'il tourne : sudo systemctl status camera-service.";
+        showCameraMessage(message, describeError(error), 'danger');
+    }
+}
+
+async function activateHttpFallback(reason) {
+    stopLocalStream();
+    usingHttpFallback = true;
+    usingBrowserCamera = false;
+
+    if (videoElement) {
+        videoElement.classList.add('d-none');
+    }
+    if (fallbackImage) {
+        fallbackImage.classList.remove('d-none');
+    }
+    if (planBBadge) {
+        planBBadge.classList.remove('d-none');
+    }
+
+    const permissionDenied = reason && ['NotAllowedError', 'SecurityError'].includes(reason.name);
+    const message = permissionDenied
+        ? 'Caméra navigateur refusée → bascule sur capture système (8080)…'
+        : 'Capture navigateur indisponible → bascule sur capture système (8080)…';
+    showCameraMessage(message, describeError(reason), 'warning');
+    await updateCameraHealthIndicator();
+    await refreshFallbackPreview();
+}
+
+async function initialiseCamera() {
+    await updateCameraHealthIndicator();
+
+    if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+        await activateHttpFallback(new Error('API getUserMedia indisponible sur ce navigateur'));
+        return;
+    }
+
+    try {
+        await startBrowserCamera();
+    } catch (error) {
+        console.warn('Impossible de démarrer la caméra navigateur, bascule sur fallback HTTP', error);
+        await activateHttpFallback(error);
+    }
+}
+
+async function handleCameraRetry(event) {
+    event?.preventDefault?.();
+    hideCameraMessage();
+    try {
+        await startBrowserCamera();
+    } catch (error) {
+        await activateHttpFallback(error);
+    }
+}
+
+async function listVideoDevices() {
+    if (!navigator.mediaDevices || !navigator.mediaDevices.enumerateDevices) {
+        return { devices: [], error: 'API enumerateDevices indisponible' };
+    }
+    try {
+        const devices = await navigator.mediaDevices.enumerateDevices();
+        return { devices: devices.filter((device) => device.kind === 'videoinput'), error: null };
+    } catch (error) {
+        return { devices: [], error: describeError(error) };
+    }
+}
+
+function renderDiagnosticsDevices(devices, errorMessage) {
+    if (!diagnosticsDevicesList) {
+        return;
+    }
+    diagnosticsDevicesList.innerHTML = '';
+
+    if (errorMessage) {
+        const li = document.createElement('li');
+        li.className = 'list-group-item list-group-item-danger';
+        li.textContent = errorMessage;
+        diagnosticsDevicesList.appendChild(li);
+        return;
+    }
+
+    if (!devices.length) {
+        const li = document.createElement('li');
+        li.className = 'list-group-item';
+        li.textContent = 'Aucune caméra détectée par le navigateur.';
+        diagnosticsDevicesList.appendChild(li);
+        return;
+    }
+
+    devices.forEach((device, index) => {
+        const li = document.createElement('li');
+        li.className = 'list-group-item';
+        const label = device.label || `Caméra ${index + 1}`;
+        li.innerHTML = `<strong>${label}</strong><br><small>ID: ${device.deviceId || 'inconnu'}</small>`;
+        diagnosticsDevicesList.appendChild(li);
+    });
+}
+
+async function openCameraDiagnostics(event) {
+    event?.preventDefault?.();
+    const { devices, error } = await listVideoDevices();
+    renderDiagnosticsDevices(devices, error);
+
+    const health = await requestCameraHealth();
+    if (diagnosticsHealthPre) {
+        diagnosticsHealthPre.textContent = JSON.stringify(health.payload, null, 2);
+    }
+    if (diagnosticsTimestamp) {
+        diagnosticsTimestamp.textContent = new Date().toLocaleString('fr-FR');
+    }
+
+    const modalLib = window.bootstrap?.Modal;
+    if (modalLib && diagnosticsModal) {
+        modalLib.getOrCreateInstance(diagnosticsModal).show();
+    }
+}
+
+async function captureFromVideo() {
+    if (!videoElement) {
+        throw new Error('Aucune vidéo active');
+    }
+    await ensureVideoReady(videoElement);
+
+    const width = videoElement.videoWidth || 1280;
+    const height = videoElement.videoHeight || 720;
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    const context = canvas.getContext('2d');
+    if (!context) {
+        throw new Error("Impossible d'accéder au contexte canvas");
+    }
+    context.drawImage(videoElement, 0, 0, width, height);
+
+    return await new Promise((resolve, reject) => {
+        canvas.toBlob((blob) => {
+            if (blob) {
+                resolve(blob);
+            } else {
+                reject(new Error("Impossible de générer l'image"));
+            }
+        }, 'image/jpeg', 0.92);
+    });
+}
+
+async function takePhoto() {
+    const health = await updateCameraHealthIndicator();
+
+    if (localStream && usingBrowserCamera) {
+        const blob = await captureFromVideo();
+        return { blob, origin: 'browser' };
+    }
+
+    if (!health.ok) {
+        const message = "Service caméra indisponible (8080). Vérifie qu'il tourne : sudo systemctl status camera-service.";
+        const details = health.payload?.error ? String(health.payload.error) : '';
+        showCameraMessage(message, details, 'danger');
+        throw new Error(message);
+    }
+
+    try {
+        const blob = await fetchSnapshotBlob();
+        usingHttpFallback = true;
+        if (fallbackImage) {
+            fallbackImage.classList.remove('d-none');
+        }
+        if (planBBadge) {
+            planBBadge.classList.remove('d-none');
+        }
+        displayFallbackImage(blob);
+        return { blob, origin: 'http-fallback' };
+    } catch (error) {
+        const message = "Service caméra indisponible (8080). Vérifie qu'il tourne : sudo systemctl status camera-service.";
+        showCameraMessage(message, describeError(error), 'danger');
+        throw new Error(message);
+    }
+}
+
+window.addEventListener('beforeunload', () => {
+    stopLocalStream();
+    revokeFallbackUrl();
 });
 
 function capturePhoto() {
@@ -369,34 +774,36 @@ function capturePhoto() {
 }
 
 async function takePicture() {
+    let redirected = false;
     try {
-        const payload = {
-            planB: !!window.SimpleBoothCameraClient?.isPlanBActive,
-            cameraServerBase: window.SimpleBoothCameraClient?.cameraServerBase || null,
-        };
+        const { blob, origin } = await takePhoto();
+        const formData = new FormData();
+        formData.append('image', blob, `capture_${Date.now()}.jpg`);
+        formData.append('origin', origin);
 
         const response = await fetch('/capture', {
             method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify(payload),
+            body: formData,
         });
-        
+
         const result = await response.json();
-        
-        if (result.success) {
-            // Rediriger vers la page de révision
+
+        if (response.ok && result.success) {
+            redirected = true;
+            resetCaptureButton();
             window.location.href = '/review';
-        } else {
-            throw new Error(result.error || 'Erreur de capture');
+            return;
         }
-        
+
+        const errorMessage = result.error || 'Erreur de capture';
+        throw new Error(errorMessage);
     } catch (error) {
         console.error('Erreur lors de la capture:', error);
-        alert('Erreur lors de la prise de photo: ' + error.message);
-        
-        resetCaptureButton();
+        alert('Erreur lors de la prise de photo: ' + (error.message || error));
+    } finally {
+        if (!redirected) {
+            resetCaptureButton();
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add a standalone Flask + Picamera2 camera microservice with health and snapshot endpoints and ship a systemd unit file
- update the main Flask backend to consume the new snapshot endpoint, accept uploaded images, and improve error messaging
- replace the frontend capture workflow with a getUserMedia-first strategy that falls back to the HTTP snapshot service and document the new setup steps

## Testing
- python -m compileall app.py camera_service

------
https://chatgpt.com/codex/tasks/task_e_68ded8a8fab4832a95f995a7da319005